### PR TITLE
Fix deprecated function call

### DIFF
--- a/lib/directory_picker.dart
+++ b/lib/directory_picker.dart
@@ -66,7 +66,7 @@ class DirectoryPickerData extends InheritedWidget {
       : super(child: child);
 
   static DirectoryPickerData of(BuildContext context) {
-    return context.inheritFromWidgetOfExactType(DirectoryPickerData);
+    return context.inheritFromWidgetOfExactType<DirectoryPickerData>();
   }
 
   @override


### PR DESCRIPTION
Replace the deprecated function call `inheritFromWidgetOfExactType(type)` with `inheritFromWidgetOfExactType<type>()`.